### PR TITLE
Pusherのライブラリを別のものに変更しました

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - MTBBarcodeScanner (5.0.11)
   - NWWebSocket (0.5.2)
-  - pusher_client (2.1.0):
+  - pusher_channels_flutter (0.0.1):
     - Flutter
-    - PusherSwift (~> 9.0)
-  - PusherSwift (9.2.2):
+    - PusherSwift (~> 10.0.0)
+  - PusherSwift (10.0.0):
     - NWWebSocket (~> 0.5.2)
     - TweetNacl (~> 1.0.0)
   - qr_code_scanner (0.2.0):
@@ -17,7 +17,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - pusher_client (from `.symlinks/plugins/pusher_client/ios`)
+  - pusher_channels_flutter (from `.symlinks/plugins/pusher_channels_flutter/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
 
@@ -31,8 +31,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  pusher_client:
-    :path: ".symlinks/plugins/pusher_client/ios"
+  pusher_channels_flutter:
+    :path: ".symlinks/plugins/pusher_channels_flutter/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
   shared_preferences_ios:
@@ -42,8 +42,8 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   NWWebSocket: 21f0c73639815da3272862c912275b26102aa80c
-  pusher_client: ff61542f68affe690a4deed3ab6a209089f0962d
-  PusherSwift: 8b252244aca6a662572be48a97b756d14cd7542c
+  pusher_channels_flutter: 36d51ae4a94195bb9109c2009de2f8445e222d67
+  PusherSwift: 264eaceb921a5f8e166f01a2242371179540c7ff
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,24 +1,38 @@
 PODS:
   - Flutter (1.0.0)
   - MTBBarcodeScanner (5.0.11)
+  - NWWebSocket (0.5.2)
+  - pusher_client (2.1.0):
+    - Flutter
+    - PusherSwift (~> 9.0)
+  - PusherSwift (9.2.2):
+    - NWWebSocket (~> 0.5.2)
+    - TweetNacl (~> 1.0.0)
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - TweetNacl (1.0.2)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - pusher_client (from `.symlinks/plugins/pusher_client/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
 
 SPEC REPOS:
   trunk:
     - MTBBarcodeScanner
+    - NWWebSocket
+    - PusherSwift
+    - TweetNacl
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  pusher_client:
+    :path: ".symlinks/plugins/pusher_client/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
   shared_preferences_ios:
@@ -27,9 +41,13 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
+  NWWebSocket: 21f0c73639815da3272862c912275b26102aa80c
+  pusher_client: ff61542f68affe690a4deed3ab6a209089f0962d
+  PusherSwift: 8b252244aca6a662572be48a97b756d14cd7542c
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
 COCOAPODS: 1.11.3

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ class RouterApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.watch(_fetchAuthInfoFutureProvider);
-    ref.watch(pusherClientProvider);
+    ref.watch(pusherChannelProvider);
 
     ref.watch(accountStoreProvider);
     final router = ref.read(routerProvider);

--- a/lib/providers/session_event_provider.dart
+++ b/lib/providers/session_event_provider.dart
@@ -5,43 +5,72 @@ import 'dart:developer';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:poipla_app/data/events/result_count.dart';
 import 'package:poipla_app/providers/user_provider.dart';
-import 'package:pusher_client/pusher_client.dart';
+import 'package:pusher_channels_flutter/pusher_channels_flutter.dart';
 
 const pusherApiKey = String.fromEnvironment('PUSHER_API_KEY');
 
-final pusherClientProvider = Provider.autoDispose<PusherClient>((ref) {
-  final client = PusherClient(
-    pusherApiKey,
-    PusherOptions(
-      cluster: 'ap3',
-    ),
-  );
-  client.connect().then((value) {
-    log('pusher is connected');
+final pusherChannelProvider =
+    Provider.autoDispose<PusherChannelsFlutter>((ref) {
+  PusherChannelsFlutter pusher = PusherChannelsFlutter.getInstance();
+  pusher
+      .init(
+    apiKey: pusherApiKey,
+    cluster: 'ap3',
+  )
+      .catchError((e, st) {
+    log('start pusher error', error: e, stackTrace: st);
   });
-  ref.onDispose(() {
-    client.disconnect();
+  pusher.connect().catchError((e, st) {
+    log('start pusher error', error: e, stackTrace: st);
   });
-  return client;
+  return pusher;
 });
+// final pusherClientProvider = Provider.autoDispose<PusherClient>((ref) {
+//   final client = PusherClient(
+//     pusherApiKey,
+//     PusherOptions(
+//       cluster: 'ap3',
+//     ),
+//   );
+//   client.connect().then((value) {
+//     log('pusher is connected');
+//   });
+//   ref.onDispose(() {
+//     client.disconnect();
+//   });
+//   return client;
+// });
 final sessionCountEventStreamProvider = StreamProvider.autoDispose
     .family<ResultCount, int>((ref, int dustBoxId) async* {
-  final pusherClient = ref.read(pusherClientProvider);
+  final pusherClient = ref.read(pusherChannelProvider);
   final streamController = StreamController<ResultCount>();
-  pusherClient.subscribe('dust-box-$dustBoxId').bind('result-count', (event) {
-    log('on session count event, socketId:${pusherClient.getSocketId()}');
-    log('result-count-event:${event?.data}');
-    if (event?.data != null) {
-      final json = jsonDecode(event!.data!);
-      streamController.sink.add(ResultCount.fromJson(json));
-    }
-    // jsonDecode()
-  });
+  pusherClient.subscribe(
+      channelName: 'dust-box-$dustBoxId',
+      onEvent: (event) {
+        if (event.eventName == 'result-count') {
+          log('on session count event, socketId:${pusherClient.getSocketId()}');
+          log('result-count-event:${event.data}');
+          if (event.data != null) {
+            final json = jsonDecode(event.data!);
+            streamController.sink.add(ResultCount.fromJson(json));
+          }
+        }
+      });
+  // pusherClient.subscribe('dust-box-$dustBoxId').bind('result-count', (event) {
+  //   log('on session count event, socketId:${pusherClient.getSocketId()}');
+  //   log('result-count-event:${event?.data}');
+  //   if (event?.data != null) {
+  //     final json = jsonDecode(event!.data!);
+  //     streamController.sink.add(ResultCount.fromJson(json));
+  //   }
+  //   // jsonDecode()
+  // });
 
   ref.read(accountStoreProvider);
   streamController.onCancel = () {
     log('unsubscribe sessionCountEventStream: $dustBoxId');
-    pusherClient.unsubscribe('dust-box-$dustBoxId');
+    pusherClient.unsubscribe(channelName: 'dust-box-$dustBoxId');
+    // pusherClient.unsubscribe('dust-box-$dustBoxId');
   };
 
   yield* streamController.stream;

--- a/lib/providers/session_event_provider.dart
+++ b/lib/providers/session_event_provider.dart
@@ -23,23 +23,10 @@ final pusherChannelProvider =
   pusher.connect().catchError((e, st) {
     log('start pusher error', error: e, stackTrace: st);
   });
+  ref.onDispose(() => pusher.disconnect());
   return pusher;
 });
-// final pusherClientProvider = Provider.autoDispose<PusherClient>((ref) {
-//   final client = PusherClient(
-//     pusherApiKey,
-//     PusherOptions(
-//       cluster: 'ap3',
-//     ),
-//   );
-//   client.connect().then((value) {
-//     log('pusher is connected');
-//   });
-//   ref.onDispose(() {
-//     client.disconnect();
-//   });
-//   return client;
-// });
+
 final sessionCountEventStreamProvider = StreamProvider.autoDispose
     .family<ResultCount, int>((ref, int dustBoxId) async* {
   final pusherClient = ref.read(pusherChannelProvider);
@@ -56,15 +43,6 @@ final sessionCountEventStreamProvider = StreamProvider.autoDispose
           }
         }
       });
-  // pusherClient.subscribe('dust-box-$dustBoxId').bind('result-count', (event) {
-  //   log('on session count event, socketId:${pusherClient.getSocketId()}');
-  //   log('result-count-event:${event?.data}');
-  //   if (event?.data != null) {
-  //     final json = jsonDecode(event!.data!);
-  //     streamController.sink.add(ResultCount.fromJson(json));
-  //   }
-  //   // jsonDecode()
-  // });
 
   ref.read(accountStoreProvider);
   streamController.onCancel = () {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -471,13 +471,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  pusher_client:
+  pusher_channels_flutter:
     dependency: "direct main"
     description:
-      name: pusher_client
+      name: pusher_channels_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.5"
   qr_code_scanner:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   bordered_text: ^2.0.0
   ruby_text: ^3.0.1
   qr_code_scanner: ^0.7.0
-  pusher_client: ^2.0.0
+  pusher_channels_flutter: '^1.0.1'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# したこと
pusher_clientが古くなっていたため、
iOSのネイティブ部分との依存関係の解決ができなくなってしまい
ビルドができない状態となっていました。
そこでpusher_clientをpusher_channel_clientに置き換え、
pusher_clientに依存している部分のコードをpusher_channel_clientで再実装を行いました。
